### PR TITLE
[BOJ] 2240번 자두나무

### DIFF
--- a/DynamicProgramming1/2240.py
+++ b/DynamicProgramming1/2240.py
@@ -1,0 +1,26 @@
+t, w = map(int, input().split())
+
+jadu = list(int(input()) for _ in range(t))
+dp = [[0]*(w+1) for _ in range(t)]
+
+if jadu[0] == 1:
+    dp[0][0] = 1
+else:
+    dp[0][1] = 1
+
+for i in range(1, t):
+    if jadu[i] == 1:
+        dp[i][0] = dp[i-1][0]+1
+    else:
+        dp[i][0] = dp[i-1][0]
+
+for i in range(1, t):
+    for j in range(1, w+1):
+        if j % 2 == jadu[i] % 2:  # 해당 칸에서 자두를 얻을 수 없을 경우
+            dp[i][j] = dp[i-1][j]
+        else:
+            # 해당 칸에서 자두를 얻을 수 있는 경우
+            # 움직여서 자두 얻기 vs 안움직여서 자두 얻기
+            dp[i][j] = max(dp[i-1][j-1], dp[i-1][j])+1
+
+print(max(dp[-1]))


### PR DESCRIPTION
### [BOJ] 2240번 자두나무

### 알고리즘
- dp

### 풀이과정
- 이 문제에서 명심해야 할 것은. 짝수번 움직이면 1번 나무 밑에 있고, 홀수번 움직이면 2번 나무 밑에 있다는 것이다.
- dp[i][j]는 i초에 j번 움직였을 때 잡을 수 있는 자두의 수이다.
- 해당 초마다 자두는 두 가지 선택 중 하나를 할 수 있다.
- 1. 움직인다
- 2. 움직이지 않는다.
- 그리고 해당 나무 밑에 위치하면 자두를 잡을 수 있다.

- 이에 따라 다음과 같이 식을 세울 수 있다.
- 자두가 짝수번 움직였을 때 1번 자두 나무에서 자두가 떨어진다면, 자두는 자두를 잡을 수 있다.
- 자두가 홀수번 움직였을 때 2번 자두 나무에서 자두가 떨어진다면, 자두는 자두를 잡을 수 있다.
- 즉 자두가 움직이는 횟수와 떨어지는 자두 나무의 번호가 둘 다 짝수 혹은 홀수이면 자두를 잡을 수 없다.
- 그래서 dp를 증가시키지 않고 그대로 값을 가져온다.
```python
    if j % 2 == jadu[i] % 2:
        dp[i][j] = dp[i-1][j]
```
- 하지만 자두가 움직이는 횟수와, 떨어지는 자두 나무의 번호가 짝수-홀수 혹은 홀수-짝수의 관계라면 자두를 잡을 수 있다.
- 이때 움직여서 잡는 경우와, 가만히 있어서 잡는 경우 중에 큰 값을 취한다.
```python
    dp[i][j] = max(dp[i-1][j-1], dp[i-1][j])+1
```
close #72 
