### PR TITLE
[BOJ] 9935번 문자열 폭발

### DIFF
--- a/String/9935.py
+++ b/String/9935.py
@@ -1,0 +1,16 @@
+string = input()
+boom = input()
+stack = []
+idx = 0
+while idx < len(string):
+    stack.append(string[idx])
+    if len(stack) >= len(boom):
+        if "".join(stack[-len(boom):]) == boom:
+            for _ in range(len(boom)):
+                stack.pop()
+    idx += 1
+
+if len(stack) == 0:
+    print("FRULA")
+else:
+    print("".join(stack))


### PR DESCRIPTION
### [BOJ] 9935번 문자열 폭발

### 알고리즘
- 문자열
- 스택

### 풀이과정
- 문자열을 앞에서부터 stack에 넣는다.
- stack이 폭발 문자열보다 길이가 길고, 맨 뒤에서 부터 봤을 때 폭발 문자열과 같다면 pop을 한다.

- 처음에 pop을 하는 게 아니라 리스트 슬라이스를 했더니 시간 초과가 발생했다.
- 리스트 슬라이스는 리스트의 일부를 취함으로써 시간복잡도는 복사되는 요소의 개수에 비례한다.
- 따라서 l[a:b]일 때 시간복잡도는 O(b-a)가 되어 위의 경우에는 pop보다 시간이 오래 걸린다.

close #86 
