### PR TITLE
[BOJ] 17070번 파이프 옮기기 1

### DIFF
--- a/GraphTraversal/java/BOJ17070.java
+++ b/GraphTraversal/java/BOJ17070.java
@@ -1,0 +1,121 @@
+package GraphTraversal.java;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BOJ17070 {
+    static int N;
+    static int[][] board;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        board = new int[N][N];
+        StringTokenizer st;
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                board[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int answer = 0;
+
+        if (board[N - 1][N - 1] == 1) {
+            System.out.println(answer);
+        } else {
+
+
+            Queue<Pipe> queue = new LinkedList<>();
+
+            queue.offer(new Pipe(0, 1));
+
+            while (!queue.isEmpty()) {
+                Pipe now = queue.poll();
+                int headX = now.head / N;
+                int headY = now.head % N;
+
+                int tailX = now.tail / N;
+                int tailY = now.tail % N;
+
+                if (tailX == N - 1 && tailY == N - 1) {
+                    answer++;
+                    continue;
+                }
+
+                if (headX == tailX) {
+                    // 가로
+                    if (tailY + 1 < N) {
+                        if (tailX + 1 < N) {
+                            // 대각선도 가능
+                            if (canGo(tailX + 1, tailY + 1) && canGo(tailX, tailY + 1) && canGo(tailX + 1, tailY)) {
+                                queue.offer(new Pipe(convert(tailX, tailY), convert(tailX + 1, tailY + 1)));
+                            }
+                        }
+                        if (canGo(tailX, tailY + 1)) {
+                            queue.offer(new Pipe(convert(tailX, tailY), convert(tailX, tailY + 1)));
+                        }
+                    }
+                } else if (headY == tailY) {
+                    // 세로
+                    if (tailX + 1 < N) {
+                        if (tailY + 1 < N) {
+                            // 대각선도 가능
+                            if (canGo(tailX + 1, tailY + 1) && canGo(tailX, tailY + 1) && canGo(tailX + 1, tailY)) {
+                                queue.offer(new Pipe(convert(tailX, tailY), convert(tailX + 1, tailY + 1)));
+                            }
+                        }
+                        if (canGo(tailX + 1, tailY)) {
+                            queue.offer(new Pipe(convert(tailX, tailY), convert(tailX + 1, tailY)));
+                        }
+                    }
+                } else {
+                    // 대각선
+                    if (tailX + 1 < N) {
+                        if (tailY + 1 < N) {
+                            // 대각선도 가능
+                            if (canGo(tailX + 1, tailY + 1) && canGo(tailX, tailY + 1) && canGo(tailX + 1, tailY)) {
+                                queue.offer(new Pipe(convert(tailX, tailY), convert(tailX + 1, tailY + 1)));
+                            }
+                        }
+                        if (canGo(tailX + 1, tailY)) {
+                            queue.offer(new Pipe(convert(tailX, tailY), convert(tailX + 1, tailY)));
+                        }
+                    }
+                    if (tailY + 1 < N) {
+                        if (canGo(tailX, tailY + 1)) {
+                            queue.offer(new Pipe(convert(tailX, tailY), convert(tailX, tailY + 1)));
+                        }
+                    }
+                }
+
+            }
+            System.out.println(answer);
+        }
+    }
+
+    static class Pipe {
+        int head;
+        int tail;
+
+        public Pipe(int head, int tail) {
+            this.head = head;
+            this.tail = tail;
+        }
+    }
+
+    static int convert(int x, int y) {
+        return x * N + y;
+    }
+
+    static boolean canGo(int x, int y) {
+        if (board[x][y] == 1) {
+            return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
### [BOJ] 17070번 파이프 옮기기 1

### 알고리즘
- 완전탐색

### 풀이과정
- N이 16이하이기 때문에 완전 탐색으로 풀어도 될 것 같다고 판단했다.
- 파이프의 머리와 꼬리의 좌표를 비교해 가로, 세로, 대각선을 구분한다.
- 그리고 각각 갈 수 있을 때 queue에 넣어가며 탐색을 계속한다.
- 파이프의 꼬리가 마지막에 도달했다면 answer을 증가시킨다.

close #220 
